### PR TITLE
release/3.20240601.0:  QWEB-4546 (2024.05.29)

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -2,6 +2,13 @@ require 'uri'
 
 module Paperclip
   class UrlGenerator
+    class << self
+      def encoder
+        @encoder ||= URI::RFC2396_Parser.new
+      end
+      delegate :escape, :unescape, to: :encoder
+    end
+
     def initialize(attachment, attachment_options)
       @attachment = attachment
       @attachment_options = attachment_options
@@ -61,7 +68,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        self.class.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 


### PR DESCRIPTION
Updates UrlGenerator to not use deprecated `URI.encode` method